### PR TITLE
[BUGFIX] Require typo3/minimal for installing TYPO3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,14 @@ before_install:
 - phpenv config-rm xdebug.ini
 
 install:
-- composer require-typo3-version "$TYPO3_VERSION"
-- git checkout .
-- export TYPO3_PATH_ROOT=$PWD/.Build/public
+- >
+  composer require typo3/minimal=$TYPO3_VERSION;
+- >
+  echo;
+  echo "Restoring the composer.json";
+  git checkout .;
+->
+  export TYPO3_PATH_ROOT=$PWD/.Build/public;
 
 script:
 - >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - remove the example extension (#6)
 
 ### Fixed
+- Require typo3/minimal for installing TYPO3 (#17)
 - require mkforms >= 3.0.14 (#14)
 - fix autoloading when running the tests in the BE module in non-composer mode (#11)
 - use the correct package name for mkforms in composer.json

--- a/composer.json
+++ b/composer.json
@@ -65,10 +65,6 @@
         "ci": [
             "@ci:static"
         ],
-        "require-typo3-version": [
-            "@php -r '$conf=json_decode(file_get_contents(__DIR__.\"/composer.json\"),true);$conf[\"require\"][\"typo3/cms-core\"]=$_SERVER[\"argv\"][1];file_put_contents(__DIR__.\"/composer.json\",json_encode($conf,JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT).chr(10));'",
-            "@composer install"
-        ],
         "link-extension": [
             "@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
             "@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/onetimeaccount\") || symlink(__DIR__,$extFolder);'"


### PR DESCRIPTION
This fixes the TYPO3 installation process using Composer on Travis
both for 7.6 as well as 8.7.