### PR TITLE
[TASK] Make the PHPUnit test runner configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - DATABASE_USER=travis DATABASE_HOST=localhost DATABASE_PORT=3306 DATABASE_NAME=typo3 DATABASE_PASSWORD=''
   - TYPO3_PATH_ROOT=$PWD/.Build/public
   matrix:
-  - TYPO3_VERSION="^7.6"
+  - TYPO3_VERSION="^7.6" RUN_TESTS_COMMAND=".Build/public/typo3/cli_dispatch.phpsh phpunit"
 
 matrix:
   exclude:
@@ -30,9 +30,6 @@ before_install:
 install:
 - >
   composer require typo3/minimal=$TYPO3_VERSION;
-  if [ "$TYPO3_VERSION" == "^8.7" ]; then
-    composer require pagemachine/typo3-composer-legacy-cli;
-  fi;
   composer show;
 - >
   .Build/vendor/bin/typo3cms install:setup --non-interactive --site-setup-type="site"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 5.5 (#29)
 
 ### Fixed
+- Make the PHPUnit test runner configurable (#37)
 
 ## 2.1.0
 

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "scripts": {
         "ci:php:lint": "find *.php Classes/ Configuration/ Migrations/ pi1/ Tests/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:tests:unit": ".Build/public/typo3/cli_dispatch.phpsh phpunit Tests/Unit/",
+        "ci:tests:unit": "$RUN_TESTS_COMMAND Tests/Unit/",
         "ci:tests": [
             "@ci:tests:unit"
         ],


### PR DESCRIPTION
This makes it possible to have different test runners in TYPO3 7.6
and 8.7.