### PR TITLE
[BUGFIX] Update the composer package name of static-info-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Update the composer package name of static-info-tables (#47)
 - Stop PHP-linting the removed Migrations/ folder (#46)
 - Use the public mkforms render method (#45)
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0",
         "typo3/cms-core": "^7.6.23 || ^8.7.9",
         "typo3/cms-frontend": "^7.6.23 || ^8.7.9",
-        "sjbr/static-info-tables": "^6.4.0",
+        "typo3-ter/static-info-tables": "^6.4.0",
         "oliverklee/oelib": "^2.0.0 || ^3.0.0",
         "dmk/mkforms": "^3.0.14"
     },


### PR DESCRIPTION
The old package sjbr/static-info-tables has been abandoned.
typo3-ter/static-info-tables should be used instead.