### PR TITLE
[TASK] Use the EXT: notation for language files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Display the name of the current functional test (#97, #98)
 
 ### Changed
+- Use the EXT: notation for language files (#76, #117)
 - Sort the Composer dependencies (#111)
 - Allow 9.5-compatible versions of mkforms and rn_base (#108)
 - Update the testing libraries (#93, #96)

--- a/Classes/BackEnd/FlexForms.php
+++ b/Classes/BackEnd/FlexForms.php
@@ -196,8 +196,7 @@ class FlexForms
             return;
         }
 
-        $languageFilePath =
-            ExtensionManagementUtility::extPath('onetimeaccount') . 'Resources/Private/Language/locallang_db.xlf';
+        $languageFilePath = 'EXT:onetimeaccount/Resources/Private/Language/locallang_db.xlf';
         /** @var XliffParser $xmlParser */
         $xmlParser = GeneralUtility::makeInstance(XliffParser::class);
         self::$languageLabels = $xmlParser->getParsedData($languageFilePath, $this->getLanguageService()->lang);


### PR DESCRIPTION
With TYPO3 8.7, this is now possible.

Fixes #76