### PR TITLE
[BUGFIX] Do not crash if no user groups are selected in the flexforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not crash if no user groups are selected in the flexforms (#137, #138)
 
 ## 4.0.1
 

--- a/Tests/Unit/FrontEnd/DefaultControllerTest.php
+++ b/Tests/Unit/FrontEnd/DefaultControllerTest.php
@@ -747,4 +747,41 @@ class DefaultControllerTest extends UnitTestCase
 
         self::assertFalse($result);
     }
+
+    /**
+     * @test
+     */
+    public function getUidOfFirstUserGroupForOneGroupReturnsThatGroupUid()
+    {
+        $groupUid = 42;
+        $this->subject->setConfigurationValue('groupForNewFeUsers', (string)$groupUid);
+
+        $result = $this->subject->getUidOfFirstUserGroup();
+
+        self::assertSame($groupUid, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getUidOfFirstUserGroupForTwoGroupsReturnsFirstGroupUid()
+    {
+        $this->subject->setConfigurationValue('groupForNewFeUsers', '1,2');
+
+        $result = $this->subject->getUidOfFirstUserGroup();
+
+        self::assertSame(1, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function getUidOfFirstUserGroupForNoGroupReturnsZero()
+    {
+        $this->subject->setConfigurationValue('groupForNewFeUsers', '');
+
+        $result = $this->subject->getUidOfFirstUserGroup();
+
+        self::assertSame(0, $result);
+    }
 }

--- a/pi1/class.tx_onetimeaccount_pi1.php
+++ b/pi1/class.tx_onetimeaccount_pi1.php
@@ -576,16 +576,15 @@ class tx_onetimeaccount_pi1 extends Tx_Oelib_TemplateHelper implements Tx_Oelib_
     }
 
     /**
-     * Returns the UID of the first user group shown in the FE. If there are no
-     * user groups, the result will be zero.
+     * Returns the UID of the first user group shown in the FE.
      *
-     * @return int UID of the first user group
+     * @return int UID of the first user group, will be 0 if no group is configured
      */
     public function getUidOfFirstUserGroup(): int
     {
         $userGroups = $this->getUncheckedUidsOfAllowedUserGroups();
 
-        return $userGroups[0];
+        return $userGroups[0] ?? 0;
     }
 
     /**


### PR DESCRIPTION
Fixes #137