### PR TITLE
[BUGFIX] Do not cache vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not cache `vendor/` on Travis CI (#142)
 - Do not crash if no user groups are selected in the flexforms (#137, #138)
 
 ## 4.0.1


### PR DESCRIPTION
This causes too much trouble with version conflicts.

Caching the Composer cache should be enough anyway.