### PR TITLE
[BUGFIX] Add .0 version suffixes to PHP version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Add `.0` version suffixes to PHP version requirements (#161)
 - Update the "for" attribute of labels (#156, #160)
 - Load the flexforms language labels in the default language as well (#158, #159)
 - Always use Composer-installed versions of the dev tools (#157)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/oliverklee/ext-onetimeaccount"
     },
     "require": {
-        "php": "~7.0 || ~7.1 || ~7.2",
+        "php": "~7.0.0 || ~7.1.0 || ~7.2.0",
         "digedag/rn-base": "^1.10.5",
         "dmk/mkforms": "^9.5.2",
         "oliverklee/oelib": "^3.0.3",


### PR DESCRIPTION
Allowing PHP `~7.4` would allow PHP 7.5 as well (even if that version
most probably will not exist), while `~7.4.0` will not due to the way
the `~` operator for Composer version requirements works.