### PR TITLE
[BUGFIX] Relax the dependencies to allow non-Composer installs again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Relax the dependencies to allow non-Composer installations again (#181)
 
 ## 4.2.0
 

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     "require": {
         "php": "~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0",
         "digedag/rn-base": "^1.11.4",
-        "dmk/mkforms": "^9.5.4",
+        "dmk/mkforms": "^9.5.2",
         "oliverklee/oelib": "^3.2.0",
-        "sjbr/static-info-tables": "^6.8.0",
+        "sjbr/static-info-tables": "^6.7.0",
         "typo3/cms-core": "^8.7.9 || ^9.5.7",
         "typo3/cms-felogin": "^8.7 || ^9.5",
         "typo3/cms-frontend": "^8.7 || ^9.5",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,9 +10,9 @@ $EM_CONF[$_EXTKEY] = [
             'php' => '7.0.0-7.4.99',
             'typo3' => '8.7.0-9.5.99',
             'felogin' => '8.7.0-9.5.99',
-            'mkforms' => '9.5.4-9.5.99',
+            'mkforms' => '9.5.2-9.5.99',
             'oelib' => '3.2.0-3.99.99',
-            'static_info_tables' => '6.8.0-6.99.99',
+            'static_info_tables' => '6.7.0-6.99.99',
         ],
         'conflicts' => [
             'kb_md5fepw' => '0.0.0-',


### PR DESCRIPTION
Some extension do not provide all versions via the TER. Now the
dependency versions are relaxed so that installs in non-Composer systems
is possible in TYPO3 8.7 again.