### PR TITLE
[TASK] Allow the development Composer plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Allow the development Composer plugins (#192)
 
 ## 4.2.1
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,11 @@
             "*": "dist"
         },
         "sort-packages": true,
-        "vendor-dir": ".Build/vendor"
+        "vendor-dir": ".Build/vendor",
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
+        }
     },
     "scripts": {
         "php:fix": ".Build/vendor/bin/php-cs-fixer --config=Configuration/php-cs-fixer.php fix Classes pi1 Tests && .Build/vendor/bin/phpcbf Classes Configuration pi1 Tests",


### PR DESCRIPTION
This allows running Composer plugins with Composer >= 2.2 when
developing this extension.