### PR TITLE
[BUGFIX] Pin Composer on CI to version 2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.2
       - name: "Run PHP lint"
         run: "composer ci:php:lint"
     strategy:
@@ -43,7 +43,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.2
           extensions: zip
       - name: "Show Composer version"
         run: composer --version
@@ -78,7 +78,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.2
           extensions: zip
       - name: "Show Composer version"
         run: composer --version
@@ -128,7 +128,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.2
           extensions: zip, mysqli
       - name: "Show Composer version"
         run: composer --version


### PR DESCRIPTION
This avoids breakage due to type problems with TYPO3 8LTS.