### PR TITLE
[BUGFIX] Disable the flexforms as long as they are empty

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -18,11 +18,11 @@ defined('TYPO3_MODE') || die();
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['onetimeaccount_withautologin']
     = 'recursive,select_key,pages';
 // These two commands add the flexform configuration for the plugin.
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['onetimeaccount_withoutautologin'] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    'onetimeaccount_withautologin',
-    'FILE:EXT:onetimeaccount/Configuration/FlexForms/Plugin.xml'
-);
+// $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['onetimeaccount_withautologin'] = 'pi_flexform';
+// \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+//     'onetimeaccount_withautologin',
+//     'FILE:EXT:onetimeaccount/Configuration/FlexForms/Plugin.xml'
+// );
 
 // This makes the plugin selectable in the BE.
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
@@ -40,8 +40,8 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['onetimeaccou
 $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['onetimeaccount_withoutautologin']
     = 'recursive,select_key,pages';
 // These two commands add the flexform configuration for the plugin.
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['onetimeaccount_withoutautologin'] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-    'onetimeaccount_withoutautologin',
-    'FILE:EXT:onetimeaccount/Configuration/FlexForms/Plugin.xml'
-);
+// $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['onetimeaccount_withoutautologin'] = 'pi_flexform';
+// \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+//     'onetimeaccount_withoutautologin',
+//     'FILE:EXT:onetimeaccount/Configuration/FlexForms/Plugin.xml'
+// );


### PR DESCRIPTION
Flexforms without any elements lead to a warning when editing the
content element. So we need to disable them for the time being.

Part of #218