### PR TITLE
[BUGFIX] Stop using CamelCase for the extension PHP namespace

### DIFF
--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Controller;
+namespace OliverKlee\Onetimeaccount\Controller;
 
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 

--- a/Classes/Controller/UserWithAutologinController.php
+++ b/Classes/Controller/UserWithAutologinController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Controller;
+namespace OliverKlee\Onetimeaccount\Controller;
 
 /**
  * Plugin for creating a front-end user and directly logging it in.

--- a/Classes/Controller/UserWithoutAutologinController.php
+++ b/Classes/Controller/UserWithoutAutologinController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Controller;
+namespace OliverKlee\Onetimeaccount\Controller;
 
 /**
  * Plugin for creating a front-end user, but without the autologin.

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -5,5 +5,5 @@ defined('TYPO3_MODE') || die('Access denied.');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'onetimeaccount',
     'Configuration/TypoScript',
-    'OneTimeAccount'
+    'Onetimeaccount'
 );

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -5,7 +5,7 @@ defined('TYPO3_MODE') || die();
 // This makes the plugin selectable in the BE.
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
     // extension name, matching the PHP namespace
-    'OliverKlee.OneTimeAccount',
+    'OliverKlee.Onetimeaccount',
     // arbitrary, but unique plugin name (not visible in the BE)
     'WithAutologin',
     // plugin title, as visible in the drop-down in the BE
@@ -27,7 +27,7 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['onetimea
 // This makes the plugin selectable in the BE.
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
     // extension name, matching the PHP namespace
-    'OliverKlee.OneTimeAccount',
+    'OliverKlee.Onetimeaccount',
     // arbitrary, but unique plugin name (not visible in the BE)
     'WithoutAutologin',
     // plugin title, as visible in the drop-down in the BE

--- a/Tests/Functional/HelloWorldTest.php
+++ b/Tests/Functional/HelloWorldTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Tests\Functional;
+namespace OliverKlee\Onetimeaccount\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 

--- a/Tests/Unit/Controller/UserWithAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithAutologinControllerTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Tests\Unit\Controller;
+namespace OliverKlee\Onetimeaccount\Tests\Unit\Controller;
 
-use OliverKlee\OneTimeAccount\Controller\UserWithAutologinController;
+use OliverKlee\Onetimeaccount\Controller\UserWithAutologinController;
 use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -13,8 +13,8 @@ use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
- * @covers \OliverKlee\OneTimeAccount\Controller\UserWithAutologinController
- * @covers \OliverKlee\OneTimeAccount\Controller\AbstractUserController
+ * @covers \OliverKlee\Onetimeaccount\Controller\UserWithAutologinController
+ * @covers \OliverKlee\Onetimeaccount\Controller\AbstractUserController
  */
 class UserWithAutologinControllerTest extends UnitTestCase
 {

--- a/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OliverKlee\OneTimeAccount\Tests\Unit\Controller;
+namespace OliverKlee\Onetimeaccount\Tests\Unit\Controller;
 
-use OliverKlee\OneTimeAccount\Controller\UserWithoutAutologinController;
+use OliverKlee\Onetimeaccount\Controller\UserWithoutAutologinController;
 use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -13,8 +13,8 @@ use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
- * @covers \OliverKlee\OneTimeAccount\Controller\UserWithoutAutologinController
- * @covers \OliverKlee\OneTimeAccount\Controller\AbstractUserController
+ * @covers \OliverKlee\Onetimeaccount\Controller\UserWithoutAutologinController
+ * @covers \OliverKlee\Onetimeaccount\Controller\AbstractUserController
  */
 class UserWithoutAutologinControllerTest extends UnitTestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,12 @@
 	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {
-			"OliverKlee\\OneTimeAccount\\": "Classes/"
+			"OliverKlee\\Onetimeaccount\\": "Classes/"
 		}
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"OliverKlee\\OneTimeAccount\\Tests\\": "Tests/"
+			"OliverKlee\\Onetimeaccount\\Tests\\": "Tests/"
 		}
 	},
 	"config": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,12 +26,12 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'oliverklee.de',
     'autoload' => [
         'psr-4' => [
-            'OliverKlee\\OneTimeAccount\\' => 'Classes/',
+            'OliverKlee\\Onetimeaccount\\' => 'Classes/',
         ],
     ],
     'autoload-dev' => [
         'psr-4' => [
-            'OliverKlee\\OneTimeAccount\\Tests\\' => 'Tests/',
+            'OliverKlee\\Onetimeaccount\\Tests\\' => 'Tests/',
         ],
     ],
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,38 +8,38 @@ defined('TYPO3_MODE') or die('Access denied.');
         // This makes the plugin available for front-end rendering.
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             // extension name, matching the PHP namespace
-            'OliverKlee.OneTimeAccount',
+            'OliverKlee.Onetimeaccount',
             // arbitrary, but unique plugin name (not visible in the BE)
             'WithAutologin',
             // all actions
             [
-                \OliverKlee\OneTimeAccount\Controller\UserWithAutologinController::class => 'new',
+                \OliverKlee\Onetimeaccount\Controller\UserWithAutologinController::class => 'new',
             ],
             // non-cacheable actions
             [
-                \OliverKlee\OneTimeAccount\Controller\UserWithAutologinController::class => 'new',
+                \OliverKlee\Onetimeaccount\Controller\UserWithAutologinController::class => 'new',
             ]
         );
         // This makes the plugin available for front-end rendering.
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             // extension name, matching the PHP namespace
-            'OliverKlee.OneTimeAccount',
+            'OliverKlee.Onetimeaccount',
             // arbitrary, but unique plugin name (not visible in the BE)
             'WithoutAutologin',
             // all actions
             [
-                \OliverKlee\OneTimeAccount\Controller\UserWithoutAutologinController::class => 'new',
+                \OliverKlee\Onetimeaccount\Controller\UserWithoutAutologinController::class => 'new',
             ],
             // non-cacheable actions
             [
-                \OliverKlee\OneTimeAccount\Controller\UserWithoutAutologinController::class => 'new',
+                \OliverKlee\Onetimeaccount\Controller\UserWithoutAutologinController::class => 'new',
             ]
         );
     } else {
         // This makes the plugin available for front-end rendering.
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             // extension name, matching the PHP namespace
-            'OliverKlee.OneTimeAccount',
+            'OliverKlee.Onetimeaccount',
             // arbitrary, but unique plugin name (not visible in the BE)
             'WithAutologin',
             // all actions
@@ -54,7 +54,7 @@ defined('TYPO3_MODE') or die('Access denied.');
         // This makes the plugin available for front-end rendering.
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             // extension name, matching the PHP namespace
-            'OliverKlee.OneTimeAccount',
+            'OliverKlee.Onetimeaccount',
             // arbitrary, but unique plugin name (not visible in the BE)
             'WithoutAutologin',
             // all actions


### PR DESCRIPTION
This fixes using locallang labels in Fluid without explicitly
having to provide the extension key.