### PR TITLE
[BUGFIX] Fix crash when using the login form

### DIFF
--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -58,8 +58,12 @@ abstract class AbstractUserController extends ActionController
         $this->view->assign('user', $newUser);
     }
 
-    public function createAction(FrontendUser $user): string
+    public function createAction(?FrontendUser $user = null): string
     {
+        if (!$user instanceof FrontendUser) {
+            return '';
+        }
+
         $this->enrichUser($user);
         $this->userRepository->add($user);
 

--- a/Tests/Unit/Controller/UserWithAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithAutologinControllerTest.php
@@ -180,4 +180,24 @@ final class UserWithAutologinControllerTest extends UnitTestCase
 
         $this->subject->createAction($user);
     }
+
+    /**
+     * @test
+     */
+    public function createActionWithNullUserNotAddsAnythingToRepository(): void
+    {
+        $this->userRepositoryProphecy->add(Argument::any())->shouldNotBeCalled();
+
+        $this->subject->createAction(null);
+    }
+
+    /**
+     * @test
+     */
+    public function createActionWithoutUserNotAddsAnythingToRepository(): void
+    {
+        $this->userRepositoryProphecy->add(Argument::any())->shouldNotBeCalled();
+
+        $this->subject->createAction();
+    }
 }

--- a/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
@@ -180,4 +180,24 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
 
         $this->subject->createAction($user);
     }
+
+    /**
+     * @test
+     */
+    public function createActionWithNullUserNotAddsAnythingToRepository(): void
+    {
+        $this->userRepositoryProphecy->add(Argument::any())->shouldNotBeCalled();
+
+        $this->subject->createAction(null);
+    }
+
+    /**
+     * @test
+     */
+    public function createActionWithoutUserNotAddsAnythingToRepository(): void
+    {
+        $this->userRepositoryProphecy->add(Argument::any())->shouldNotBeCalled();
+
+        $this->subject->createAction();
+    }
 }


### PR DESCRIPTION
When an FE login form is used that is on the same page as the
user creation form, a login must not lead to a crash even if it
is tried directy after a user has been created.