### PR TITLE
[TASK] Explicitly persist the created user

### DIFF
--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -11,6 +11,7 @@ use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Onetimeaccount\Service\CredentialsGenerator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 
 /**
  * Base class to implement most of the functionality of the plugin except for the specifics of what should
@@ -29,6 +30,11 @@ abstract class AbstractUserController extends ActionController
     protected $userGroupRepository;
 
     /**
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
+
+    /**
      * @var CredentialsGenerator
      */
     protected $credentialsGenerator;
@@ -41,6 +47,11 @@ abstract class AbstractUserController extends ActionController
     public function injectFrontendUserGroupRepository(FrontendUserGroupRepository $repository): void
     {
         $this->userGroupRepository = $repository;
+    }
+
+    public function injectPersistenceManager(PersistenceManagerInterface $persistenceManager): void
+    {
+        $this->persistenceManager = $persistenceManager;
     }
 
     public function injectCredentialsGenerator(CredentialsGenerator $generator): void
@@ -73,6 +84,7 @@ abstract class AbstractUserController extends ActionController
 
         $password = $this->enrichUser($user);
         $this->userRepository->add($user);
+        $this->persistenceManager->persistAll();
 
         $username = $user->getUsername();
 

--- a/Tests/Unit/Controller/UserWithAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithAutologinControllerTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -53,6 +54,11 @@ final class UserWithAutologinControllerTest extends UnitTestCase
     protected $userGroupRepositoryProphecy;
 
     /**
+     * @var ObjectProphecy<PersistenceManagerInterface>
+     */
+    protected $persistenceManagerProphecy;
+
+    /**
      * @var ObjectProphecy<CredentialsGenerator>
      *
      * We can make this property private once we drop support for TYPO3 V9.
@@ -79,6 +85,10 @@ final class UserWithAutologinControllerTest extends UnitTestCase
         $this->userGroupRepositoryProphecy = $this->prophesize(FrontendUserGroupRepository::class);
         $userGroupRepository = $this->userGroupRepositoryProphecy->reveal();
         $this->subject->injectFrontendUserGroupRepository($userGroupRepository);
+
+        $this->persistenceManagerProphecy = $this->prophesize(PersistenceManagerInterface::class);
+        $persistenceManager = $this->persistenceManagerProphecy->reveal();
+        $this->subject->injectPersistenceManager($persistenceManager);
 
         $this->usernameGeneratorProphecy = $this->prophesize(CredentialsGenerator::class);
         $usernameGenerator = $this->usernameGeneratorProphecy->reveal();
@@ -186,10 +196,21 @@ final class UserWithAutologinControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function createActionAddsProvidedUserToRepository(): void
+    public function createActionWithUserAddsProvidedUserToRepository(): void
     {
         $user = new FrontendUser();
         $this->userRepositoryProphecy->add($user)->shouldBeCalled();
+
+        $this->subject->createAction($user);
+    }
+
+    /**
+     * @test
+     */
+    public function createActionWithUserPersistsEverything(): void
+    {
+        $user = new FrontendUser();
+        $this->persistenceManagerProphecy->persistAll()->shouldBeCalled();
 
         $this->subject->createAction($user);
     }
@@ -210,6 +231,26 @@ final class UserWithAutologinControllerTest extends UnitTestCase
     public function createActionWithoutUserNotAddsAnythingToRepository(): void
     {
         $this->userRepositoryProphecy->add(Argument::any())->shouldNotBeCalled();
+
+        $this->subject->createAction();
+    }
+
+    /**
+     * @test
+     */
+    public function createActionWithNullUserNotPersistsAnything(): void
+    {
+        $this->persistenceManagerProphecy->persistAll()->shouldNotBeCalled();
+
+        $this->subject->createAction(null);
+    }
+
+    /**
+     * @test
+     */
+    public function createActionWithoutUserNotPersistsAnything(): void
+    {
+        $this->persistenceManagerProphecy->persistAll()->shouldNotBeCalled();
 
         $this->subject->createAction();
     }


### PR DESCRIPTION
This is required so that the created user then can be used for starting
a new user session.