### PR TITLE
[FEATURE] Display an alert with the login status after user creation

### DIFF
--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -76,21 +76,15 @@ abstract class AbstractUserController extends ActionController
      * after creating a user with this action. (This will use the current URL as form target, causing the user to be
      * null as it had been sent via a POST request.)
      */
-    public function createAction(?FrontendUser $user = null): string
+    public function createAction(?FrontendUser $user = null): void
     {
         if (!$user instanceof FrontendUser) {
-            return '';
+            return;
         }
 
-        $password = $this->enrichUser($user);
+        $this->enrichUser($user);
         $this->userRepository->add($user);
         $this->persistenceManager->persistAll();
-
-        $username = $user->getUsername();
-
-        return '<p>User has been created.</p>' .
-            '<p>Username: ' . \htmlspecialchars($username, ENT_QUOTES | ENT_HTML5) . '<br/>' .
-            'Password: ' . \htmlspecialchars($password, ENT_QUOTES | ENT_HTML5) . '</p>';
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -153,6 +153,14 @@
 				<source>Proceed</source>
 				<target>Weiter</target>
 			</trans-unit>
+			<trans-unit id="alert.userCreatedAndLoggedIn">
+				<source>The user has been created, and you now are logged in as the new user.</source>
+				<target>Der User wurde angelegt, und Sie sind jetzt als der neue User eingeloggt.</target>
+			</trans-unit>
+			<trans-unit id="alert.userCreatedNotLoggedIn">
+				<source>The user has been created, but the automatic login with the new user has not successful.</source>
+				<target>Der User wurde angelegt, aber der automatische Login mit den neuen User ist fehlgeschlagen.</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -116,6 +116,12 @@
 			<trans-unit id="submit">
 				<source>Proceed</source>
 			</trans-unit>
+			<trans-unit id="alert.userCreatedAndLoggedIn">
+				<source>The user has been created, and you now are logged in as the new user.</source>
+			</trans-unit>
+			<trans-unit id="alert.userCreatedNotLoggedIn">
+				<source>The user has been created, but the automatic login with the new user has not successful.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/LoginStatus.html
+++ b/Resources/Private/Partials/LoginStatus.html
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+    <f:security.ifAuthenticated>
+        <f:then>
+            <div class="alert alert-success" role="alert">
+                <f:translate key="alert.userCreatedAndLoggedIn"/>
+            </div>
+        </f:then>
+        <f:else>
+            <div class="alert alert-warning" role="alert">
+                <f:translate key="alert.userCreatedNotLoggedIn"/>
+            </div>
+        </f:else>
+    </f:security.ifAuthenticated>
+</html>

--- a/Resources/Private/Templates/UserWithAutologin/Create.html
+++ b/Resources/Private/Templates/UserWithAutologin/Create.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+    <f:layout name="Default"/>
+
+    <f:section name="main">
+        <f:render partial="LoginStatus"/>
+    </f:section>
+</html>

--- a/Resources/Private/Templates/UserWithoutAutologin/Create.html
+++ b/Resources/Private/Templates/UserWithoutAutologin/Create.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+    <f:layout name="Default"/>
+
+    <f:section name="main">
+        <f:render partial="LoginStatus"/>
+    </f:section>
+</html>


### PR DESCRIPTION
Also stop displaying the credentials (which was a temporary measure
for manual testing).

Fixes #275