### PR TITLE
[BUGFIX] Skip validation for `newAction`

### DIFF
--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -61,6 +61,8 @@ abstract class AbstractUserController extends ActionController
 
     /**
      * Creates the user creation form (which initially is empty).
+     *
+     * @TYPO3\CMS\Extbase\Annotation\IgnoreValidation\IgnoreValidation("user")
      */
     public function newAction(?FrontendUser $user = null): void
     {


### PR DESCRIPTION
This form needs to be able to receive incomplete objects and show
validation errors. To avoid redirect loops, we must not validate
the user model here.

Fixes #289