### PR TITLE
[FEATURE] Add onetimeaccount marker to the user session

### DIFF
--- a/Classes/Service/Autologin.php
+++ b/Classes/Service/Autologin.php
@@ -15,6 +15,11 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  */
 class Autologin implements SingletonInterface
 {
+    /**
+     * @var non-empty-string
+     */
+    public const ONETIMEACCOUNT_SESSION_MARKER = 'onetimeaccount';
+
     public function createSessionForUser(FrontendUser $user, string $plaintextPassword): void
     {
         $userAuthentication = $this->getFrontendUserAuthentication();
@@ -25,6 +30,8 @@ class Autologin implements SingletonInterface
 
         $userAuthentication->checkPid = false;
         $userAuthentication->start();
+        $userAuthentication->setKey('user', self::ONETIMEACCOUNT_SESSION_MARKER, true);
+        $userAuthentication->storeSessionData();
     }
 
     /**

--- a/Tests/Functional/Service/AutologinTest.php
+++ b/Tests/Functional/Service/AutologinTest.php
@@ -84,4 +84,24 @@ final class AutologinTest extends FunctionalTestCase
         self::assertSame(1, $userDataFromAuthentication['uid']);
         self::assertSame('max', $userDataFromAuthentication['username']);
     }
+
+    /**
+     * @test
+     */
+    public function createSessionForUserSetsOneTimeAccountFlagInSession(): void
+    {
+        $this->importDataSet(__DIR__ . '/Fixtures/User.xml');
+        $user = $this->userRepository->findByUid(1);
+        self::assertInstanceOf(FrontendUser::class, $user);
+        $password = 'max-has-a-password';
+
+        $this->subject->createSessionForUser($user, $password);
+
+        $frontEndController = $GLOBALS['TSFE'];
+        self::assertInstanceOf(TypoScriptFrontendController::class, $frontEndController);
+        $authentication = $frontEndController->fe_user;
+        self::assertInstanceOf(FrontendUserAuthentication::class, $authentication);
+
+        self::assertTrue($authentication->getKey('user', 'onetimeaccount'));
+    }
 }


### PR DESCRIPTION
This allows the seminars extension to log the user out again
after they have signed up for an event.

Fixes #246