### PR TITLE
[TASK] Update typo3/testing-framework

### DIFF
--- a/Tests/Functional/Service/AutologinTest.php
+++ b/Tests/Functional/Service/AutologinTest.php
@@ -19,14 +19,8 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 final class AutologinTest extends FunctionalTestCase
 {
-    /**
-     * @var array<string>
-     */
     protected $testExtensionsToLoad = ['typo3conf/ext/feuserextrafields', 'typo3conf/ext/onetimeaccount'];
 
-    /**
-     * @var array<int, string>
-     */
     protected $coreExtensionsToLoad = ['extbase'];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 		"squizlabs/php_codesniffer": "^3.6.2",
 		"symfony/yaml": "^4.4.37 || ^5.3.14 || ^6.0.2",
 		"typo3/coding-standards": "^0.5.2",
-		"typo3/testing-framework": "^4.15.5 || ^6.16.4"
+		"typo3/testing-framework": "^4.15.5 || ^6.16.5"
 	},
 	"replace": {
 		"typo3-ter/onetimeaccount": "self.version"


### PR DESCRIPTION
Also remove redundant type annotations to fix PHPStan warnings.