### PR TITLE
[BUGFIX] Properly quote version numbers in the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -68,7 +68,7 @@ jobs:
           - "ts:lint"
           - "yaml:lint"
         php-version:
-          - 7.4
+          - "7.4"
   xliff-lint:
     name: "Xliff linter"
     runs-on: ubuntu-20.04
@@ -120,41 +120,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: lowest
   functional-tests:
     name: "Functional tests"
@@ -207,39 +207,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.2
+          - typo3-version: "^9.5"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.3
+          - typo3-version: "^9.5"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^9.5
-            php-version: 7.4
+          - typo3-version: "^9.5"
+            php-version: "7.4"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.2
+          - typo3-version: "^10.4"
+            php-version: "7.2"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.3
+          - typo3-version: "^10.4"
+            php-version: "7.3"
             composer-dependencies: lowest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: lowest

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -64,6 +64,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: ^10.4
-            php-version: 7.4
+          - typo3-version: "^10.4"
+            php-version: "7.4"
             composer-dependencies: highest


### PR DESCRIPTION
This avoids version numbers like 8.0 getting rounded to 8.