### PR TITLE
[BUGFIX] Bump the minimal 10.4 Extbase requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Bump the minimal 10.4 Extbase requirement (#366)
 
 ## 5.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"php": "^7.2.0 || ~8.0.0 || ~8.1.0",
 		"oliverklee/feuserextrafields": "^3.2.0 || ^4.2.0",
 		"typo3/cms-core": "^9.5.16 || ^10.4.6",
-		"typo3/cms-extbase": "^9.5 || ^10.4",
+		"typo3/cms-extbase": "^9.5 || ^10.4.6",
 		"typo3/cms-fluid": "^9.5 || ^10.4",
 		"typo3/cms-frontend": "^9.5 || ^10.4",
 		"typo3fluid/fluid": "^2.6.10"


### PR DESCRIPTION
Extbase < 10.4.6 has a bug that causes it to stumble over PHPDoc
annotations in the repository.