### PR TITLE
[TASK] Stop running the functional tests in parallel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,7 @@
 		"ci:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
 		"ci:tests:functional": [
 			"@ci:tests:create-directories",
-			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml {}';"
+			".Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional"
 		],
 		"ci:tests:unit": [
 			"@ci:tests:create-directories",


### PR DESCRIPTION
Parallel testing breaks when we introduce abstract test classes for functional tests.

In addition, our functional test are so small that running them in parallel does not make much of a difference.