### PR TITLE
[BUGFIX] Stop using the deprecated `ObjectManager` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for TYPO3 9LTS (#438)
 
 ### Fixed
+- Stop using the deprecated `ObjectManager` in tests (#444)
 - Stop using the deprecated `TYPO3_MODE` constant (#443)
 - Fix the plugin registration for TYPO3 10LTS/11LTS (#440)
 

--- a/Tests/Functional/Service/AutologinTest.php
+++ b/Tests/Functional/Service/AutologinTest.php
@@ -8,8 +8,6 @@ use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use OliverKlee\Onetimeaccount\Service\Autologin;
 use Psr\Log\NullLogger;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -41,8 +39,9 @@ final class AutologinTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        $this->userRepository = $objectManager->get(FrontendUserRepository::class);
+        /** @var FrontendUserRepository $userRepository */
+        $userRepository = $this->get(FrontendUserRepository::class);
+        $this->userRepository = $userRepository;
 
         $this->setUpFakeFrontEnd();
 

--- a/Tests/Functional/Validation/UserValidatorTest.php
+++ b/Tests/Functional/Validation/UserValidatorTest.php
@@ -6,9 +6,7 @@ namespace OliverKlee\Onetimeaccount\Tests\Functional\Validation;
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Onetimeaccount\Validation\UserValidator;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Extbase\Validation\Error;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
@@ -61,11 +59,7 @@ final class UserValidatorTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        if ((new Typo3Version())->getMajorVersion() < 10) {
-            $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
-        } else {
-            $GLOBALS['LANG'] = $this->get(LanguageService::class);
-        }
+        $GLOBALS['LANG'] = $this->get(LanguageService::class);
 
         $this->subject = new UserValidator();
     }


### PR DESCRIPTION
Fixes #410
Fixes #441