### PR TITLE
[CLEANUP] Simplify the mocks in the controller tests

### DIFF
--- a/Tests/Unit/Controller/UserWithAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithAutologinControllerTest.php
@@ -29,13 +29,9 @@ final class UserWithAutologinControllerTest extends AbstractUserControllerTest
         $this->setDummyRequestData();
 
         // We need to create an accessible mock in order to be able to set the protected `view`.
-        // We can drop the additional arguments to skip the original constructor once we drop support for TYPO3 V9.
         $this->subject = $this->getAccessibleMock(
             UserWithAutologinController::class,
-            ['redirect', 'forward', 'redirectToUri'],
-            [],
-            '',
-            false
+            ['redirect', 'forward', 'redirectToUri']
         );
 
         $this->setUpAndInjectSharedDependencies();

--- a/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
@@ -32,13 +32,9 @@ final class UserWithoutAutologinControllerTest extends AbstractUserControllerTes
         $this->setUpFakeFrontEnd();
 
         // We need to create an accessible mock in order to be able to set the protected `view`.
-        // We can drop the additional arguments to skip the original constructor once we drop support for TYPO3 V9.
         $this->subject = $this->getAccessibleMock(
             UserWithoutAutologinController::class,
-            ['redirect', 'forward', 'redirectToUri'],
-            [],
-            '',
-            false
+            ['redirect', 'forward', 'redirectToUri']
         );
 
         $this->setUpAndInjectSharedDependencies();


### PR DESCRIPTION
Starting with TYPO3 10LTS, controllers do not require any constructor parameters anymore.

Fixes #415