### PR TITLE
[FEATURE] Add a fallback for the user groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
-- Add a selector for the user group (#460)
+- Add a selector for the user group (#460, #467)
 - Add a Rector configuration file (#454)
 
 ### Changed

--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -170,16 +170,19 @@ abstract class AbstractUserController extends ActionController
 
     private function enrichWithGroup(FrontendUser $user, ?int $userGroupUid): void
     {
-        if (!\is_int($userGroupUid) || $userGroupUid < 1) {
-            return;
-        }
-
         $userGroupSetting = $this->settings['groupsForNewUsers'] ?? null;
         $userGroupUids = \is_string($userGroupSetting) ? GeneralUtility::intExplode(',', $userGroupSetting, true) : [];
-        if (\in_array($userGroupUid, $userGroupUids, true)) {
+        if (\is_int($userGroupUid) && $userGroupUid >= 1 && \in_array($userGroupUid, $userGroupUids, true)) {
             $group = $this->userGroupRepository->findByUid($userGroupUid);
             if ($group instanceof FrontendUserGroup) {
                 $user->addUserGroup($group);
+            }
+        }
+
+        if ($userGroupUids !== [] && $user->getUserGroup()->count() === 0) {
+            $userGroups = $this->userGroupRepository->findByUids($userGroupUids);
+            foreach ($userGroups as $userGroup) {
+                $user->addUserGroup($userGroup);
             }
         }
     }

--- a/Tests/Unit/Controller/Fixtures/TestingQueryResult.php
+++ b/Tests/Unit/Controller/Fixtures/TestingQueryResult.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKlee\Onetimeaccount\Tests\Unit\Controller\Fixtures;
+
+use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+
+/**
+ * Testing query result that holds an object storage for its objects.
+ *
+ * @implements QueryResultInterface<FrontendUserGroup>
+ */
+final class TestingQueryResult implements QueryResultInterface
+{
+    /**
+     * @var ObjectStorage<FrontendUserGroup>
+     */
+    private $objectStorage;
+
+    /**
+     * @param ObjectStorage<FrontendUserGroup> $storage
+     */
+    public function __construct(ObjectStorage $storage)
+    {
+        $this->objectStorage = $storage;
+    }
+
+    public function current()
+    {
+        return $this->objectStorage->current();
+    }
+
+    public function next()
+    {
+        $this->objectStorage->next();
+    }
+
+    public function key()
+    {
+        return $this->objectStorage->key();
+    }
+
+    public function valid()
+    {
+        return $this->objectStorage->valid();
+    }
+
+    public function rewind()
+    {
+        $this->objectStorage->rewind();
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->objectStorage->offsetExists($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->objectStorage->offsetGet($offset);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->objectStorage->offsetSet($offset, $value);
+    }
+
+    public function offsetUnset($offset)
+    {
+        $this->objectStorage->offsetUnset($offset);
+    }
+
+    public function count()
+    {
+        return $this->objectStorage->count();
+    }
+
+    /**
+     * @return never
+     *
+     * @throws \BadMethodCallException
+     */
+    public function getQuery()
+    {
+        throw new \BadMethodCallException('Not implemented.', 1665661687);
+    }
+
+    public function getFirst()
+    {
+        $this->objectStorage->rewind();
+        return $this->objectStorage->current();
+    }
+
+    public function toArray()
+    {
+        return $this->objectStorage->toArray();
+    }
+}


### PR DESCRIPTION
Now, if the user group selector is hidden in the FE, or if no valid user groups are selected, the user will get all user groups from the configuration.

Fixes #419