### PR TITLE
[FEATURE] Hide the user group selector if there is only one group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## x.y.z
 
 ### Added
-- Add a selector for the user group (#460, #467)
+- Add a selector for the user group (#460, #467, #468)
 - Add a Rector configuration file (#454)
 
 ### Changed

--- a/Resources/Private/Partials/User.html
+++ b/Resources/Private/Partials/User.html
@@ -295,26 +295,28 @@
             </oelib:isFieldEnabled>
 
             <oelib:isFieldEnabled fieldName="userGroup">
-                <div class="row mb-3">
-                    <div class="col-sm-2">
-                        <f:translate key="userGroup"/>
-                    </div>
-                    <div class="col-sm-10">
-                        <f:for each="{userGroups}" as="userGroup">
-                            <div class="form-check">
-                                <f:form.radio name="userGroup" value="{userGroup.uid}"
-                                              id="onetimeaccount-userGroup-{userGroup.uid}"
-                                              checked="{selectedUserGroup} == {userGroup.uid}"
-                                              class="form-check-input" errorClass="is-invalid"/>
-                                <label for="onetimeaccount-userGroup-{userGroup.uid}" class="form-check-label">
-                                    {userGroup.title}
-                                </label>
-                            </div>
-                        </f:for>
+                <f:if condition="{userGroups -> f:count()} > 1">
+                    <div class="row mb-3">
+                        <div class="col-sm-2">
+                            <f:translate key="userGroup"/>
+                        </div>
+                        <div class="col-sm-10">
+                            <f:for each="{userGroups}" as="userGroup">
+                                <div class="form-check">
+                                    <f:form.radio name="userGroup" value="{userGroup.uid}"
+                                                  id="onetimeaccount-userGroup-{userGroup.uid}"
+                                                  checked="{selectedUserGroup} == {userGroup.uid}"
+                                                  class="form-check-input" errorClass="is-invalid"/>
+                                    <label for="onetimeaccount-userGroup-{userGroup.uid}" class="form-check-label">
+                                        {userGroup.title}
+                                    </label>
+                                </div>
+                            </f:for>
 
-                        <f:render partial="ValidationResult" arguments="{property: 'userGroup'}"/>
+                            <f:render partial="ValidationResult" arguments="{property: 'userGroup'}"/>
+                        </div>
                     </div>
-                </div>
+                </f:if>
             </oelib:isFieldEnabled>
 
             <oelib:isFieldEnabled fieldName="comments">


### PR DESCRIPTION
A one-item (or zero-item) radiobutton group does not make sense.

Fixes #458