### PR TITLE
[TASK] Make displaying the group selector non-configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Require oelib >= 5.0 (#477)
 
 ### Removed
+- Make displaying the group selector non-configurable (#479)
 - Drop the elaborate validation for the user group (#478)
 
 ### Fixed

--- a/Classes/Configuration/FlexForms.php
+++ b/Classes/Configuration/FlexForms.php
@@ -30,7 +30,6 @@ class FlexForms
         'www',
         'dateOfBirth',
         'status',
-        'userGroup',
         'comments',
         'privacy',
     ];

--- a/Resources/Private/Partials/User.html
+++ b/Resources/Private/Partials/User.html
@@ -294,30 +294,28 @@
                 </div>
             </oelib:isFieldEnabled>
 
-            <oelib:isFieldEnabled fieldName="userGroup">
-                <f:if condition="{userGroups -> f:count()} > 1">
-                    <div class="row mb-3">
-                        <div class="col-sm-2">
-                            <f:translate key="userGroup"/>
-                        </div>
-                        <div class="col-sm-10">
-                            <f:for each="{userGroups}" as="userGroup">
-                                <div class="form-check">
-                                    <f:form.radio name="userGroup" value="{userGroup.uid}"
-                                                  id="onetimeaccount-userGroup-{userGroup.uid}"
-                                                  checked="{selectedUserGroup} == {userGroup.uid}"
-                                                  class="form-check-input" errorClass="is-invalid"
-                                                  additionalAttributes="{required: 'required'}"
-                                    />
-                                    <label for="onetimeaccount-userGroup-{userGroup.uid}" class="form-check-label">
-                                        {userGroup.title}
-                                    </label>
-                                </div>
-                            </f:for>
-                        </div>
+            <f:if condition="{userGroups -> f:count()} > 1">
+                <div class="row mb-3">
+                    <div class="col-sm-2">
+                        <f:translate key="userGroup"/>
                     </div>
-                </f:if>
-            </oelib:isFieldEnabled>
+                    <div class="col-sm-10">
+                        <f:for each="{userGroups}" as="userGroup">
+                            <div class="form-check">
+                                <f:form.radio name="userGroup" value="{userGroup.uid}"
+                                              id="onetimeaccount-userGroup-{userGroup.uid}"
+                                              checked="{selectedUserGroup} == {userGroup.uid}"
+                                              class="form-check-input" errorClass="is-invalid"
+                                              additionalAttributes="{required: 'required'}"
+                                />
+                                <label for="onetimeaccount-userGroup-{userGroup.uid}" class="form-check-label">
+                                    {userGroup.title}
+                                </label>
+                            </div>
+                        </f:for>
+                    </div>
+                </div>
+            </f:if>
 
             <oelib:isFieldEnabled fieldName="comments">
                 <div class="row mb-3">


### PR DESCRIPTION
If the group selector is displayed, it should always be required (because optional radio buttons groups do not make sense).

In addition, it does not make sense to not display the user group selector if there is more than one user group to select from.

So make displaying the selector automatic depending on the number of available user groups, and have the radion buttons always required.

Fixes #476