### PR TITLE
[BUGFIX] Use `--no-check-lock` for `composer normalize`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
 		"ci": [
 			"@ci:static"
 		],
-		"ci:composer:normalize": "@composer normalize --dry-run",
+		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
 		"ci:coverage": [
 			"@ci:coverage:unit",
 			"@ci:coverage:functional"


### PR DESCRIPTION
Fixes #493