### PR TITLE
[TASK] Make the flexforms more compact by removing the wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Require oelib >= 5.1.0 (#555)
 
 ### Removed
+- Make the flexforms more compact by removing the suggest wizards (#561)
 
 ### Fixed
 

--- a/Configuration/FlexForms/Plugin.xml
+++ b/Configuration/FlexForms/Plugin.xml
@@ -58,6 +58,7 @@
                                 <size>1</size>
                                 <minitems>1</minitems>
                                 <maxitems>1</maxitems>
+                                <hideSuggest>1</hideSuggest>
                             </config>
                         </TCEforms>
                     </settings.systemFolderForNewUsers>
@@ -73,6 +74,7 @@
                                 <size>5</size>
                                 <minitems>1</minitems>
                                 <maxitems>99</maxitems>
+                                <hideSuggest>1</hideSuggest>
                             </config>
                         </TCEforms>
                     </settings.groupsForNewUsers>


### PR DESCRIPTION
We don't need the suggest wizard in the flexforms, and it takes up vertical space.

Fixes #530