### PR TITLE
[TASK] Improve the wording in a flexforms label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecate the plugin with autologin (#559)
 
 ### Changed
+- Improve the wording in a flexforms label (#562)
 - Switch the user validator to recognize `DateTimeInterface` (#560)
 - Require feuserextrafields >= 5.3.0 (#556)
 - Require oelib >= 5.1.0 (#555)

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -20,8 +20,8 @@
 				<target>Pflichtfelder</target>
 			</trans-unit>
 			<trans-unit id="plugin.systemFolderForNewUsers">
-				<source>System folder for the new FE user records</source>
-				<target>Systemordner für die neuen FE-User</target>
+				<source>Folder for the new FE user records</source>
+				<target>Ordner für die neuen FE-User</target>
 			</trans-unit>
 			<trans-unit id="plugin.groupsForNewUsers">
 				<source>Groups for the new FE users</source>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -8,7 +8,7 @@
 				<target>Champs d'utilisateurs FE dans le formulaire</target>
 			</trans-unit>
 			<trans-unit id="plugin.systemFolderForNewUsers">
-				<source>System folder for the new FE user records</source>
+				<source>Folder for the new FE user records</source>
 				<target>Répertoire pour le stockage des nouveaux utilisateurs FE</target>
 			</trans-unit>
 			<trans-unit id="plugin.groupsForNewUsers">

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -8,8 +8,8 @@
 				<target>Campi degli utenti di FE nella form</target>
 			</trans-unit>
 			<trans-unit id="plugin.systemFolderForNewUsers">
-				<source>System folder for the new FE user records</source>
-				<target>Cartella di sistema per nuovi utenti di FE</target>
+				<source>Folder for the new FE user records</source>
+				<target>Cartella per nuovi utenti di FE</target>
 			</trans-unit>
 			<trans-unit id="plugin.groupsForNewUsers">
 				<source>Groups for the new FE users</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -16,7 +16,7 @@
 				<source>Required fields</source>
 			</trans-unit>
 			<trans-unit id="plugin.systemFolderForNewUsers">
-				<source>System folder for the new FE user records</source>
+				<source>Folder for the new FE user records</source>
 			</trans-unit>
 			<trans-unit id="plugin.groupsForNewUsers">
 				<source>Groups for the new FE users</source>

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -12,8 +12,8 @@
 				<target>Verplichte velden</target>
 			</trans-unit>
 			<trans-unit id="plugin.systemFolderForNewUsers">
-				<source>System folder for the new FE user records</source>
-				<target>Systeemfolder voor de nieuwe FE user records</target>
+				<source>Folder for the new FE user records</source>
+				<target>Folder voor de nieuwe FE user records</target>
 			</trans-unit>
 			<trans-unit id="plugin.groupsForNewUsers">
 				<source>Groups for the new FE users</source>


### PR DESCRIPTION
The official wording in the TYPO3 core has been "folder" for ages no, not "system folder" anymore.

Fixes #515

[ci skip]