### PR TITLE
[BUGFIX] Mark all injected classes as singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Mark all injected classes as singletons (#631)
 
 ## 6.2.0
 

--- a/Classes/Service/CaptchaFactory.php
+++ b/Classes/Service/CaptchaFactory.php
@@ -7,12 +7,13 @@ namespace OliverKlee\Onetimeaccount\Service;
 use OliverKlee\Oelib\Interfaces\Time;
 use OliverKlee\Onetimeaccount\Domain\Model\Captcha;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Factory for building valid Captcha instances to be added to forms.
  */
-class CaptchaFactory
+class CaptchaFactory implements SingletonInterface
 {
     /**
      * @var non-empty-string

--- a/Classes/Validation/CaptchaValidator.php
+++ b/Classes/Validation/CaptchaValidator.php
@@ -7,6 +7,7 @@ namespace OliverKlee\Onetimeaccount\Validation;
 use OliverKlee\Onetimeaccount\Domain\Model\Captcha;
 use OliverKlee\Onetimeaccount\Service\CaptchaFactory;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Validation\Error as ValidationError;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
@@ -14,7 +15,7 @@ use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
 /**
  * Validates that the captcha is filled in correctly (if it is enabled via the configuration).
  */
-class CaptchaValidator extends AbstractValidator
+class CaptchaValidator extends AbstractValidator implements SingletonInterface
 {
     protected $acceptsEmptyValues = false;
 

--- a/Classes/Validation/UserValidator.php
+++ b/Classes/Validation/UserValidator.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Onetimeaccount\Validation;
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Oelib\Validation\AbstractConfigurationDependentValidator;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
@@ -13,7 +14,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  *
  * @extends AbstractConfigurationDependentValidator<FrontendUser>
  */
-class UserValidator extends AbstractConfigurationDependentValidator
+class UserValidator extends AbstractConfigurationDependentValidator implements SingletonInterface
 {
     protected function getModelClassName(): string
     {

--- a/Tests/Unit/Service/CaptchaFactoryTest.php
+++ b/Tests/Unit/Service/CaptchaFactoryTest.php
@@ -8,6 +8,7 @@ use OliverKlee\Onetimeaccount\Domain\Model\Captcha;
 use OliverKlee\Onetimeaccount\Service\CaptchaFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -60,6 +61,14 @@ final class CaptchaFactoryTest extends UnitTestCase
         GeneralUtility::purgeInstances();
 
         parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function isSingleton(): void
+    {
+        self::assertInstanceOf(SingletonInterface::class, $this->subject);
     }
 
     /**

--- a/Tests/Unit/Validation/CaptchaValidatorTest.php
+++ b/Tests/Unit/Validation/CaptchaValidatorTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Onetimeaccount\Tests\Unit\Validation;
 
 use OliverKlee\Onetimeaccount\Service\CaptchaFactory;
 use OliverKlee\Onetimeaccount\Validation\CaptchaValidator;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -36,6 +37,14 @@ final class CaptchaValidatorTest extends UnitTestCase
     {
         self::assertInstanceOf(ValidatorInterface::class, $this->subject);
         self::assertInstanceOf(AbstractValidator::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function isSingleton(): void
+    {
+        self::assertInstanceOf(SingletonInterface::class, $this->subject);
     }
 
     /**

--- a/Tests/Unit/Validation/UserValidatorTest.php
+++ b/Tests/Unit/Validation/UserValidatorTest.php
@@ -6,6 +6,7 @@ namespace OliverKlee\Onetimeaccount\Tests\Unit\Validation;
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Onetimeaccount\Validation\UserValidator;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator;
 use TYPO3\CMS\Extbase\Validation\Validator\ValidatorInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -85,6 +86,14 @@ final class UserValidatorTest extends UnitTestCase
     {
         self::assertInstanceOf(ValidatorInterface::class, $this->subject);
         self::assertInstanceOf(AbstractValidator::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function isSingleton(): void
+    {
+        self::assertInstanceOf(SingletonInterface::class, $this->subject);
     }
 
     /**


### PR DESCRIPTION
This avoids warnings getting logged about non-singleton classes getting injected.

Fixes #627