### PR TITLE
[BUGFIX] Do not inject the `PasswordHashFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not inject the `PasswordHashFactory` (#633)
 - Mark all injected classes as singletons (#631)
 
 ## 6.2.0

--- a/Classes/Service/CredentialsGenerator.php
+++ b/Classes/Service/CredentialsGenerator.php
@@ -9,6 +9,7 @@ use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashInterface;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * This class can generate a username and password for a user.
@@ -21,23 +22,23 @@ class CredentialsGenerator implements SingletonInterface
     private const PASSWORD_LENGTH = 32;
 
     /**
-     * @var FrontendUserRepository
-     */
-    private $userRepository;
-
-    /**
      * @var PasswordHashInterface
      */
     private $passwordHasher;
 
+    /**
+     * @var FrontendUserRepository
+     */
+    private $userRepository;
+
+    public function __construct()
+    {
+        $this->passwordHasher = GeneralUtility::makeInstance(PasswordHashFactory::class)->getDefaultHashInstance('FE');
+    }
+
     public function injectFrontendUserRepository(FrontendUserRepository $repository): void
     {
         $this->userRepository = $repository;
-    }
-
-    public function injectPasswordHashFactory(PasswordHashFactory $factory): void
-    {
-        $this->passwordHasher = $factory->getDefaultHashInstance('FE');
     }
 
     /**

--- a/Tests/Unit/Service/CredentialsGeneratorTest.php
+++ b/Tests/Unit/Service/CredentialsGeneratorTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashInterface;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -18,6 +19,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class CredentialsGeneratorTest extends UnitTestCase
 {
+    protected $resetSingletonInstances = true;
+
     /**
      * @var CredentialsGenerator
      */
@@ -37,16 +40,17 @@ final class CredentialsGeneratorTest extends UnitTestCase
     {
         parent::setUp();
 
+        $this->passwordHasherMock = $this->createMock(PasswordHashInterface::class);
+        $passwordHashFactoryMock = $this->createMock(PasswordHashFactory::class);
+        $passwordHashFactoryMock->method('getDefaultHashInstance')->with('FE')->willReturn($this->passwordHasherMock);
+
+        GeneralUtility::addInstance(PasswordHashFactory::class, $passwordHashFactoryMock);
+
         $this->subject = new CredentialsGenerator();
 
         $this->userRepositoryMock = $this->getMockBuilder(FrontendUserRepository::class)
             ->disableOriginalConstructor()->getMock();
         $this->subject->injectFrontendUserRepository($this->userRepositoryMock);
-
-        $this->passwordHasherMock = $this->createMock(PasswordHashInterface::class);
-        $passwordHashFactoryMock = $this->createMock(PasswordHashFactory::class);
-        $passwordHashFactoryMock->method('getDefaultHashInstance')->with('FE')->willReturn($this->passwordHasherMock);
-        $this->subject->injectPasswordHashFactory($passwordHashFactoryMock);
     }
 
     /**


### PR DESCRIPTION
This class is no Singleton, and trying to inject it causes a warning to get logged.

Fixes #622