### PR TITLE
[BUGFIX] Do not skip the Extbase property validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Do not skip the Extbase property validations (#704)
 - Drop obsolete option from the plugin registration (#703)
 
 ## 6.2.1

--- a/Classes/Controller/AbstractUserController.php
+++ b/Classes/Controller/AbstractUserController.php
@@ -15,6 +15,7 @@ use OliverKlee\Onetimeaccount\Validation\CaptchaValidator;
 use OliverKlee\Onetimeaccount\Validation\UserValidator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
 
 /**
  * Base class to implement most of the functionality of the plugin except for the specifics of what should
@@ -117,14 +118,20 @@ abstract class AbstractUserController extends ActionController
     public function initializeCreateAction(): void
     {
         if ($this->arguments->hasArgument('user')) {
+            $conjunctionUserValidator = new ConjunctionValidator();
+            $conjunctionUserValidator->addValidator($this->arguments->getArgument('user')->getValidator());
             $userValidator = $this->userValidator;
             $userValidator->setSettings($this->settings);
-            $this->arguments->getArgument('user')->setValidator($userValidator);
+            $conjunctionUserValidator->addValidator($userValidator);
+            $this->arguments->getArgument('user')->setValidator($conjunctionUserValidator);
         }
         if ($this->arguments->hasArgument('captcha')) {
+            $conjunctionCaptchaValidator = new ConjunctionValidator();
+            $conjunctionCaptchaValidator->addValidator($this->arguments->getArgument('captcha')->getValidator());
             $captchaValidator = $this->captchaValidator;
             $captchaValidator->setSettings($this->settings);
-            $this->arguments->getArgument('captcha')->setValidator($captchaValidator);
+            $conjunctionCaptchaValidator->addValidator($captchaValidator);
+            $this->arguments->getArgument('captcha')->setValidator($conjunctionCaptchaValidator);
         }
     }
 

--- a/Tests/Unit/Controller/AbstractUserControllerTest.php
+++ b/Tests/Unit/Controller/AbstractUserControllerTest.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\Argument as ExtbaseArgument;
 use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\GenericObjectValidator;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\AccessibleObjectInterface;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -371,6 +373,8 @@ abstract class AbstractUserControllerTest extends UnitTestCase
         $userArgument = new ExtbaseArgument('user', FrontendUser::class);
         $userArgument->setValue($user);
         $this->controllerArguments->addArgument($userArgument);
+        $propertyValidator = new GenericObjectValidator();
+        $userArgument->setValidator($propertyValidator);
 
         $settings = ['fieldsToShow' => 'name,email', 'requiredFields' => 'email'];
         $this->subject->_set('settings', $settings);
@@ -378,7 +382,12 @@ abstract class AbstractUserControllerTest extends UnitTestCase
 
         $this->subject->initializeCreateAction();
 
-        self::assertSame($this->userValidatorMock, $userArgument->getValidator());
+        $actualValidator = $userArgument->getValidator();
+        self::assertInstanceOf(ConjunctionValidator::class, $actualValidator);
+        $validators = $actualValidator->getValidators();
+        self::assertCount(2, $validators);
+        self::assertContains($propertyValidator, $validators);
+        self::assertContains($this->userValidatorMock, $validators);
     }
 
     /**
@@ -402,6 +411,8 @@ abstract class AbstractUserControllerTest extends UnitTestCase
         $captchaArgument = new ExtbaseArgument('captcha', Captcha::class);
         $captchaArgument->setValue($captcha);
         $this->controllerArguments->addArgument($captchaArgument);
+        $propertyValidator = new GenericObjectValidator();
+        $captchaArgument->setValidator($propertyValidator);
 
         $settings = ['captcha' => '1'];
         $this->subject->_set('settings', $settings);
@@ -409,7 +420,12 @@ abstract class AbstractUserControllerTest extends UnitTestCase
 
         $this->subject->initializeCreateAction();
 
-        self::assertSame($this->captchaValidatorMock, $captchaArgument->getValidator());
+        $actualValidator = $captchaArgument->getValidator();
+        self::assertInstanceOf(ConjunctionValidator::class, $actualValidator);
+        $validators = $actualValidator->getValidators();
+        self::assertCount(2, $validators);
+        self::assertContains($propertyValidator, $validators);
+        self::assertContains($this->captchaValidatorMock, $validators);
     }
 
     /**


### PR DESCRIPTION
This adds another safeguard against invalid input (instead of risking a DB error when inserting the data).

Fixes #620