### PR TITLE
[BUGFIX] Avoid the deprecated `CacheNullifyer::flushMakeInstanceCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Avoid using deprecated oelib functionality (#714)
 
 ## 6.3.0
 

--- a/Tests/Unit/Controller/AbstractUserControllerTest.php
+++ b/Tests/Unit/Controller/AbstractUserControllerTest.php
@@ -8,7 +8,6 @@ use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUserGroup;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserGroupRepository;
 use OliverKlee\FeUserExtraFields\Domain\Repository\FrontendUserRepository;
-use OliverKlee\Oelib\Testing\CacheNullifyer;
 use OliverKlee\Onetimeaccount\Controller\AbstractUserController;
 use OliverKlee\Onetimeaccount\Domain\Model\Captcha;
 use OliverKlee\Onetimeaccount\Service\CaptchaFactory;
@@ -153,7 +152,6 @@ abstract class AbstractUserControllerTest extends UnitTestCase
     {
         $_GET = [];
         $_POST = [];
-        (new CacheNullifyer())->flushMakeInstanceCache();
         GeneralUtility::flushInternalRuntimeCaches();
     }
 


### PR DESCRIPTION
Now the TYPO3 Core already provides the required functionality.

Fixes #711