### PR TITLE
[TASK] Use the development PHP INI on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
       - name: "Show Composer version"
@@ -47,6 +48,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2, phive
       - name: "Show Composer version"
@@ -97,6 +99,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: none
           tools: composer:v2
           ini-values: error_reporting=E_ALL
@@ -190,6 +193,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           tools: composer:v2
           extensions: mysqli
           coverage: none

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-file: development
           coverage: pcov
           extensions: mysqli
           ini-values: pcov.directory=Classes


### PR DESCRIPTION
This will allow us to see (and error out on) all warnings and notices.

Fixes #750