### PR TITLE
[TASK] Use more expressive types in mocks

### DIFF
--- a/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
@@ -52,49 +52,49 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     /**
      * @var UserWithoutAutologinController&MockObject&AccessibleObjectInterface
      */
-    private MockObject $subject;
+    private UserWithoutAutologinController $subject;
 
     /**
      * @var TemplateView&MockObject
      */
-    private MockObject $viewMock;
+    private TemplateView $viewMock;
 
     /**
      * @var FrontendUserRepository&MockObject
      */
-    private MockObject $userRepositoryMock;
+    private FrontendUserRepository $userRepositoryMock;
 
     /**
      * @var FrontendUserGroupRepository&MockObject
      */
-    private MockObject $userGroupRepositoryMock;
+    private FrontendUserGroupRepository $userGroupRepositoryMock;
 
     /**
      * @var CredentialsGenerator&MockObject
      */
-    private MockObject $credentialsGeneratorMock;
+    private CredentialsGenerator $credentialsGeneratorMock;
 
     /**
      * @var UserValidator&MockObject
      */
-    private MockObject $userValidatorMock;
+    private UserValidator $userValidatorMock;
 
     /**
      * @var CaptchaFactory&MockObject
      */
-    private MockObject $captchaFactoryMock;
+    private CaptchaFactory $captchaFactoryMock;
 
     /**
      * @var CaptchaValidator&MockObject
      */
-    private MockObject $captchaValidatorMock;
+    private CaptchaValidator $captchaValidatorMock;
 
     private Arguments $controllerArguments;
 
     /**
      * @var FrontendUserAuthentication&MockObject
      */
-    private MockObject $userMock;
+    private FrontendUserAuthentication $userMock;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Service/CaptchaFactoryTest.php
+++ b/Tests/Unit/Service/CaptchaFactoryTest.php
@@ -36,7 +36,7 @@ final class CaptchaFactoryTest extends UnitTestCase
     /**
      * @var Context&MockObject
      */
-    private MockObject $contextMock;
+    private Context $contextMock;
 
     private CaptchaFactory $subject;
 

--- a/Tests/Unit/Service/CredentialsGeneratorTest.php
+++ b/Tests/Unit/Service/CredentialsGeneratorTest.php
@@ -26,12 +26,12 @@ final class CredentialsGeneratorTest extends UnitTestCase
     /**
      * @var FrontendUserRepository&MockObject
      */
-    private MockObject $userRepositoryMock;
+    private FrontendUserRepository $userRepositoryMock;
 
     /**
      * @var PasswordHashInterface&MockObject
      */
-    private MockObject $passwordHasherMock;
+    private PasswordHashInterface $passwordHasherMock;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/ViewHelpers/ConfigurationCheckViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/ConfigurationCheckViewHelperTest.php
@@ -26,12 +26,12 @@ final class ConfigurationCheckViewHelperTest extends UnitTestCase
     /**
      * @var RenderingContextInterface&MockObject
      */
-    private MockObject $renderingContextMock;
+    private RenderingContextInterface $renderingContextMock;
 
     /**
      * @var VariableProviderInterface&MockObject
      */
-    private MockObject $variableProviderMock;
+    private VariableProviderInterface $variableProviderMock;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
The native type for mocks should be the mocked type, not `MockObject`. This makes the intent of the code more clear.