### PR TITLE
[BUGFIX] Add missing `TestingQueryResult::setQuery()`

### DIFF
--- a/Tests/Unit/Controller/Fixtures/TestingQueryResult.php
+++ b/Tests/Unit/Controller/Fixtures/TestingQueryResult.php
@@ -103,6 +103,18 @@ final class TestingQueryResult implements QueryResultInterface
         throw new \BadMethodCallException('Not implemented.', 1665661687);
     }
 
+    /**
+     * @param QueryInterface<FrontendUserGroup> $query
+     *
+     * @return never
+     *
+     * @throws \BadMethodCallException
+     */
+    public function setQuery(QueryInterface $query): void
+    {
+        throw new \BadMethodCallException('Not implemented.', 1665661687);
+    }
+
     public function getFirst(): FrontendUserGroup
     {
         $this->objectStorage->rewind();


### PR DESCRIPTION
This is needed for running the tests on 12LTS.