### PR TITLE
[BUGFIX] Use a factory for the `LanguageService` in the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for TYPO3 12LTS (#986, #989)
+- Add support for TYPO3 12LTS (#986, #989, #996)
 
 ### Deprecated
 

--- a/Tests/Functional/Validation/CaptchaValidatorTest.php
+++ b/Tests/Functional/Validation/CaptchaValidatorTest.php
@@ -8,7 +8,7 @@ use OliverKlee\Onetimeaccount\Domain\Model\Captcha;
 use OliverKlee\Onetimeaccount\Service\CaptchaFactory;
 use OliverKlee\Onetimeaccount\Validation\CaptchaValidator;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
@@ -35,7 +35,8 @@ final class CaptchaValidatorTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $GLOBALS['LANG'] = $this->get(LanguageService::class);
+
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
 
         $this->subject = new CaptchaValidator();
 

--- a/Tests/Functional/Validation/UserValidatorTest.php
+++ b/Tests/Functional/Validation/UserValidatorTest.php
@@ -6,7 +6,7 @@ namespace OliverKlee\Onetimeaccount\Tests\Functional\Validation;
 
 use OliverKlee\FeUserExtraFields\Domain\Model\FrontendUser;
 use OliverKlee\Onetimeaccount\Validation\UserValidator;
-use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Extbase\Validation\Error;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -56,7 +56,8 @@ final class UserValidatorTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $GLOBALS['LANG'] = $this->get(LanguageService::class);
+
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->create('default');
 
         $this->subject = new UserValidator();
     }


### PR DESCRIPTION
The `LanguageService` is not available via DI in TYPO3 12LTS anymore.

Fixes #993