### PR TITLE
[TASK] Allow `instanceOf` checks in a test in a different way

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: Classes/Configuration/FlexForms.php
 
 		-
+			message: "#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#"
+			count: 1
+			path: Classes/Controller/UserWithoutAutologinController.php
+
+		-
 			message: "#^Parameter \\#1 \\$pid of method TYPO3\\\\CMS\\\\Extbase\\\\DomainObject\\\\AbstractDomainObject\\:\\:setPid\\(\\) expects int\\<0, max\\>, int given\\.$#"
 			count: 1
 			path: Classes/Controller/UserWithoutAutologinController.php
@@ -21,9 +26,29 @@ parameters:
 			path: Classes/Service/CredentialsGenerator.php
 
 		-
+			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
+			count: 1
+			path: Classes/Validation/CaptchaValidator.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 3
 			path: Tests/Functional/Validation/CaptchaValidatorTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with 0 and non\\-empty\\-list\\<non\\-empty\\-string\\> will always evaluate to true\\.$#"
+			count: 1
+			path: Tests/Unit/Configuration/ConfigurationCheckTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<string, string\\> will always evaluate to true\\.$#"
+			count: 1
+			path: Tests/Unit/Configuration/FlexFormsTest.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
+			count: 1
+			path: Tests/Unit/Controller/Fixtures/TestingQueryResult.php
 
 		-
 			message: "#^Parameter \\#1 \\$query \\(TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUserGroup\\>\\) of method OliverKlee\\\\Onetimeaccount\\\\Tests\\\\Unit\\\\Controller\\\\Fixtures\\\\TestingQueryResult\\:\\:setQuery\\(\\) should be compatible with parameter \\$query \\(TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryInterface\\<object\\>\\) of method TYPO3\\\\CMS\\\\Extbase\\\\Persistence\\\\QueryResultInterface\\<OliverKlee\\\\FeUserExtraFields\\\\Domain\\\\Model\\\\FrontendUserGroup\\>\\:\\:setQuery\\(\\)$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,5 +14,7 @@ parameters:
     - Configuration
     - Tests
 
-  # Allow instanceof checks, particularly in tests
-  checkAlwaysTrueCheckTypeFunctionCall: false
+  ignoreErrors:
+    -
+      message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
+      path: 'Tests/'


### PR DESCRIPTION
This removes one obstacle for upgrading to PHPStan 2.

Fixes #1037