### PR TITLE
[TASK] Move the Dependabot target milestone to 7.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    milestone: 23
+    milestone: 24
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -27,4 +27,4 @@ updates:
       - dependency-name: "typo3/coding-standards"
         versions: [ ">= 0.7.0" ]
     versioning-strategy: "increase"
-    milestone: 23
+    milestone: 24


### PR DESCRIPTION
There won't be a release 7.2.1.