### PR TITLE
[TASK] Make the label for "title" less ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Make the label for "title" less ambiguous (#1110)
 - Require feuserextrafields >= 6.4.0 (#1109)
 - Require the latest TYPO3 12LTS security release (#1092)
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -52,7 +52,7 @@
 				<source>Salutation and name</source>
 			</trans-unit>
 			<trans-unit id="title">
-				<source>Department/Title</source>
+				<source>Title</source>
 			</trans-unit>
 			<trans-unit id="name">
 				<source>Full name</source>


### PR DESCRIPTION
Now that we're going to have a dedicated property for the department, the "title" property does not need to double for the department anymore.