### PR TITLE
[TASK] Adapt links to the moved repositories

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -15,10 +15,10 @@ github_repository    = oliverklee/ext-onetimeaccount
 github_branch        = main
 
 # Footer links
-project_home         = https://github.com/oliverklee/ext-onetimeaccount/actions
+project_home         = https://github.com/oliverklee-de/onetimeaccount/actions
 project_contact      = mailto:typo3-coding@oliverklee.de
-project_repository   = https://github.com/oliverklee/ext-onetimeaccount/actions
-project_issues       = https://github.com/oliverklee/ext-onetimeaccount/issues
+project_repository   = https://github.com/oliverklee-de/onetimeaccount/actions
+project_issues       = https://github.com/oliverklee-de/onetimeaccount/issues
 project_discussions  =
 
 use_opensearch       =

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -5,8 +5,8 @@
     <extension class="\T3Docs\Typo3DocsTheme\DependencyInjection\Typo3DocsThemeExtension"
                project-home="https://extensions.typo3.org/extension/onetimeaccount"
                project-contact="mailto:typo3-coding@oliverklee.de"
-               project-repository="https://github.com/oliverklee/ext-onetimeaccount"
-               project-issues="https://github.com/oliverklee/ext-onetimeaccount/issues" edit-on-github-branch="main"
+               project-repository="https://github.com/oliverklee-de/onetimeaccount"
+               project-issues="https://github.com/oliverklee-de/onetimeaccount/issues" edit-on-github-branch="main"
                edit-on-github="oliverklee/ext-onetimeaccount" typo3-core-preferred="stable"
                interlink-shortcode="oliverklee/onetimeaccount"/>
     <project title="onetimeaccount" release="7.2.0" version="7.2" copyright="2026"/>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![TYPO3 V11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
 [![TYPO3 V12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
-[![License](https://img.shields.io/github/license/oliverklee/ext-onetimeaccount)](https://packagist.org/packages/oliverklee/onetimeaccount)
-[![GitHub CI status](https://github.com/oliverklee/ext-onetimeaccount/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee/ext-onetimeaccount/actions)
-[![Coverage Status](https://coveralls.io/repos/github/oliverklee/ext-onetimeaccount/badge.svg?branch=main)](https://coveralls.io/github/oliverklee/ext-onetimeaccount?branch=main)
+[![License](https://img.shields.io/github/license/oliverklee-de/ext-onetimeaccount)](https://packagist.org/packages/oliverklee/onetimeaccount)
+[![GitHub CI status](https://github.com/oliverklee-de/onetimeaccount/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/oliverklee-de/onetimeaccount/actions)
+[![Coverage Status](https://coveralls.io/repos/github/oliverklee-de/onetimeaccount/badge.svg?branch=main)](https://coveralls.io/github/oliverklee-de/onetimeaccount?branch=main)
 
 This extension provides a Bootstrap-5-compatible form that allows users to
 create a short-lived FE user account without having to enter a user name or
@@ -16,12 +16,12 @@ It also provides a CAPTCHA.
 
 |                  | URL                                                            |
 |------------------|----------------------------------------------------------------|
-| **Repository:**  | https://github.com/oliverklee/ext-onetimeaccount               |
+| **Repository:**  | https://github.com/oliverklee-de/onetimeaccount                |
 | **Read online:** | https://docs.typo3.org/p/oliverklee/onetimeaccount/main/en-us/ |
 | **TER:**         | https://extensions.typo3.org/extension/onetimeaccount/         |
 
 ## Give it a try!
 
 If you would like to test the extension yourself, there is a
-[DDEV-based TYPO3 distribution](https://github.com/oliverklee/TYPO3-testing-distribution)
+[DDEV-based TYPO3 distribution](https://github.com/oliverklee-de/TYPO3-testing-distribution)
 with this extension installed and some test records ready to go.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 	],
 	"homepage": "https://www.oliverklee.de/typo3-services/typo3-extensions/",
 	"support": {
-		"issues": "https://github.com/oliverklee/ext-onetimeaccount/issues",
-		"source": "https://github.com/oliverklee/ext-onetimeaccount"
+		"issues": "https://github.com/oliverklee-de/ext-onetimeaccount/issues",
+		"source": "https://github.com/oliverklee-de/ext-onetimeaccount"
 	},
 	"require": {
 		"php": "^7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",


### PR DESCRIPTION
This repository was moved to a GitHub organization. Hence we need to adapt all corresponding links.