### PR TITLE
[TASK] Improve the Composer script names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Show the Composer configuration
         run: composer config --global --list
       - name: Run PHP lint
-        run: "composer ci:php:lint"
+        run: "composer check:php:lint"
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +82,7 @@ jobs:
       - name: Install Composer dependencies
         run: "composer update --no-progress"
       - name: Run command
-        run: "composer ci:${{ matrix.command }}"
+        run: "composer check:${{ matrix.command }}"
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +139,7 @@ jobs:
           composer update --no-ansi --no-interaction --no-progress --with-dependencies
           composer show
       - name: Run unit tests
-        run: "composer ci:tests:unit"
+        run: "composer check:tests:unit"
     strategy:
       fail-fast: false
       matrix:
@@ -235,7 +235,7 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:tests:functional
+          composer check:tests:functional
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Start MySQL
         run: "sudo /etc/init.d/mysql start"
       - name: Run unit tests with coverage
-        run: composer ci:coverage:unit
+        run: composer check:coverage:unit
       - name: Show generated coverage files
         run: "ls -lahR .Build/coverage/"
       - name: Run functional tests with coverage
@@ -65,11 +65,11 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:coverage:functional
+          composer check:coverage:functional
       - name: Show generated coverage files
         run: "ls -lahR .Build/coverage/"
       - name: Merge coverage results
-        run: composer ci:coverage:merge
+        run: composer check:coverage:merge
       - name: Show merged coverage files
         run: "ls -lahR ./build/logs/"
       - name: Upload coverage results to Coveralls

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -483,7 +483,7 @@ fi
 case ${TEST_SUITE} in
     cgl)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:php:cs-fixer"
+            COMMAND="composer check:php:cs-fixer"
         else
             COMMAND="composer fix:php:cs"
         fi
@@ -520,9 +520,9 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerNormalize)
-        COMMAND="composer ci:composer:normalize"
+        COMMAND="composer check:composer:normalize"
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:composer:normalize"
+            COMMAND="composer check:composer:normalize"
         else
             COMMAND="composer fix:composer:normalize"
         fi
@@ -530,7 +530,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerUnused)
-        COMMAND="composer ci:composer:unused"
+        COMMAND="composer check:composer:unused"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-unused-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -579,18 +579,18 @@ case ${TEST_SUITE} in
         esac
         ;;
     lintTypoScript)
-        COMMAND="composer ci:typoscript:lint"
+        COMMAND="composer check:typoscript:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintPhp)
-        COMMAND="composer ci:php:lint"
+        COMMAND="composer check:php:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintJs)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:js"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:js"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:js"
         fi
@@ -599,7 +599,7 @@ case ${TEST_SUITE} in
         ;;
     lintCss)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:css"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:css"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:css"
         fi
@@ -607,12 +607,12 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     lintJson)
-        COMMAND="composer ci:json:lint"
+        COMMAND="composer check:json:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintYaml)
-        COMMAND="composer ci:yaml:lint"
+        COMMAND="composer check:yaml:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -622,7 +622,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)
-        COMMAND="composer ci:php:stan"
+        COMMAND="composer check:php:stan"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/composer.json
+++ b/composer.json
@@ -100,51 +100,51 @@
 		}
 	},
 	"scripts": {
-		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
-		"ci:coverage": [
-			"@ci:coverage:unit",
-			"@ci:coverage:functional"
+		"check:composer:normalize": "@composer normalize --no-check-lock --dry-run",
+		"check:coverage": [
+			"@check:coverage:unit",
+			"@check:coverage:functional"
 		],
-		"ci:coverage:functional": [
+		"check:coverage:functional": [
 			"@coverage:create-directories",
 			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --whitelist Classes --coverage-php=\".Build/coverage/{}.cov\" {}';"
 		],
-		"ci:coverage:merge": [
+		"check:coverage:merge": [
 			"@coverage:create-directories",
 			"tools/phpcov merge --clover=./build/logs/clover.xml ./.Build/coverage/"
 		],
-		"ci:coverage:unit": [
+		"check:coverage:unit": [
 			"@coverage:create-directories",
 			"phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --whitelist Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
 		],
-		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
-		"ci:php:lint": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
-		"ci:php:rector": "rector --dry-run",
-		"ci:php:sniff": "phpcs Classes Configuration Tests",
-		"ci:php:stan": "phpstan --no-progress",
-		"ci:static": [
-			"@ci:composer:normalize",
-			"@ci:php:cs-fixer",
-			"@ci:php:lint",
-			"@ci:php:rector",
-			"@ci:php:sniff",
-			"@ci:php:stan",
-			"@ci:ts:lint",
-			"@ci:xliff:lint",
-			"@ci:yaml:lint"
+		"check:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
+		"check:php:lint": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
+		"check:php:rector": "rector --dry-run",
+		"check:php:sniff": "phpcs Classes Configuration Tests",
+		"check:php:stan": "phpstan --no-progress",
+		"check:static": [
+			"@check:composer:normalize",
+			"@check:php:cs-fixer",
+			"@check:php:lint",
+			"@check:php:rector",
+			"@check:php:sniff",
+			"@check:php:stan",
+			"@check:ts:lint",
+			"@check:xliff:lint",
+			"@check:yaml:lint"
 		],
-		"ci:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
-		"ci:tests:functional": [
-			"@ci:tests:create-directories",
+		"check:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
+		"check:tests:functional": [
+			"@check:tests:create-directories",
 			"find 'Tests/Functional' -wholename '*Test.php' | parallel --gnu 'echo; echo \"Running functional test suite {}\"; .Build/vendor/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml {}';"
 		],
-		"ci:tests:unit": [
-			"@ci:tests:create-directories",
+		"check:tests:unit": [
+			"@check:tests:create-directories",
 			"phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit"
 		],
-		"ci:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
-		"ci:xliff:lint": "php Build/bin/xliff-lint lint:xliff Resources/Private/Language",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' -name '*.yml' | xargs -r php ./.Build/vendor/bin/yaml-lint",
+		"check:ts:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
+		"check:xliff:lint": "php Build/bin/xliff-lint lint:xliff Resources/Private/Language",
+		"check:yaml:lint": "find . ! -path '*.Build/*' -name '*.yml' | xargs -r php ./.Build/vendor/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p build/logs .Build/coverage",
 		"fix": [
 			"@fix:composer",
@@ -179,22 +179,22 @@
 		]
 	},
 	"scripts-descriptions": {
-		"ci:composer:normalize": "Checks the composer.json.",
-		"ci:coverage": "Generates the code coverage report for unit and functional tests.",
-		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
-		"ci:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
-		"ci:coverage:unit": "Generates the code coverage report for unit tests.",
-		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
-		"ci:php:lint": "Lints the PHP files for syntax errors.",
-		"ci:php:rector": "Checks for code for changes by Rector.",
-		"ci:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
-		"ci:php:stan": "Checks the PHP types using PHPStan.",
-		"ci:static": "Runs all static code checks (syntax, style, types).",
-		"ci:tests:functional": "Runs the functional tests.",
-		"ci:tests:unit": "Runs the unit tests.",
-		"ci:ts:lint": "Lints the TypoScript files.",
-		"ci:xliff:lint": "Lints the XLIFF files.",
-		"ci:yaml:lint": "Lints the YAML files.",
+		"check:composer:normalize": "Checks the composer.json.",
+		"check:coverage": "Generates the code coverage report for unit and functional tests.",
+		"check:coverage:functional": "Generates the code coverage report for functional tests.",
+		"check:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
+		"check:coverage:unit": "Generates the code coverage report for unit tests.",
+		"check:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
+		"check:php:lint": "Lints the PHP files for syntax errors.",
+		"check:php:rector": "Checks for code for changes by Rector.",
+		"check:php:sniff": "Checks the code style with PHP_CodeSniffer (PHPCS).",
+		"check:php:stan": "Checks the PHP types using PHPStan.",
+		"check:static": "Runs all static code checks (syntax, style, types).",
+		"check:tests:functional": "Runs the functional tests.",
+		"check:tests:unit": "Runs the unit tests.",
+		"check:ts:lint": "Lints the TypoScript files.",
+		"check:xliff:lint": "Lints the XLIFF files.",
+		"check:yaml:lint": "Lints the YAML files.",
 		"coverage:create-directories": "Creates the directories needed for recording and merging the code coverage reports.",
 		"fix": "Runs all automatic code style fixes.",
 		"fix:composer": "Normalizes all composer.json files.",


### PR DESCRIPTION
As long as we still are using the Composer scripts, the names should not be misleading.

We have had scripts with the `ci:` prefix for a long time.

However, these scripts are not only for CI, but generally for checks that can (mostly) also be run locally.

So this prefix now has been changed to `check:` to be less misleading.