### PR TITLE
[TASK] Require the latest TYPO3 security release for 12LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - Make the label for "title" less ambiguous (#1110)
 - Require feuserextrafields >= 6.6.0 (#1109, #1112)
-- Require the latest TYPO3 12LTS security release (#1092)
+- Require the latest TYPO3 12LTS security release (#1092, #1170)
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
 		"oliverklee/feuserextrafields": "^6.6",
 		"oliverklee/oelib": "^6.0",
 		"psr/http-message": "^1.0.1 || ^2.0",
-		"typo3/cms-core": "^11.5.41 || ^12.4.31",
-		"typo3/cms-extbase": "^11.5.41 || ^12.4.31",
-		"typo3/cms-fluid": "^11.5.41 || ^12.4.31",
-		"typo3/cms-frontend": "^11.5.41 || ^12.4.31",
+		"typo3/cms-core": "^11.5.41 || ^12.4.41",
+		"typo3/cms-extbase": "^11.5.41 || ^12.4.41",
+		"typo3/cms-fluid": "^11.5.41 || ^12.4.41",
+		"typo3/cms-frontend": "^11.5.41 || ^12.4.41",
 		"typo3fluid/fluid": "^2.7.4 || ^4.0.2"
 	},
 	"require-dev": {


### PR DESCRIPTION
This only affects installations using TYPO3 12LTS. Installations on TYPO3 11LTS are not affected.

Fixes #1124
