### PR TITLE
[TASK] Switch the code coverage CI job to PHP 8.2

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -84,5 +84,5 @@ jobs:
       matrix:
         include:
           - typo3-version: "^12.4"
-            php-version: "8.3"
+            php-version: "8.2"
             composer-dependencies: highest


### PR DESCRIPTION
This matches the default PHP version in `runTests.sh`.