### PR TITLE
[BUGFIX] Make a test check less strict

### DIFF
--- a/Tests/Functional/Service/CredentialsGeneratorTest.php
+++ b/Tests/Functional/Service/CredentialsGeneratorTest.php
@@ -168,8 +168,6 @@ final class CredentialsGeneratorTest extends FunctionalTestCase
 
         $this->subject->generateAndSetPasswordForUser($user);
 
-        $passwordHash = $user->getPassword();
-        self::assertStringStartsWith('$argon2i$v=19$m=65536,t=16,p=1$', $passwordHash);
-        self::assertSame(97, \strlen($passwordHash));
+        self::assertStringStartsWith('$argon2i', $user->getPassword());
     }
 }


### PR DESCRIPTION
In TYPO3 V13, the default password hashing algorithm is Argon2id, not Argon2i anymore. So be less strict about this.