### PR TITLE
[TASK] Drop the return value of `generateAndSetPasswordForUser()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
+- Stop returning the password in `generateAndSetPasswordForUser()` (#1291)
 - Drop support for TYPO3 11LTS (#1255, #1256, #1257, #1258, #1273)
 - Drop support for PHP < 8.1 (#1253, #1254, #1259, #1263, #1267)
 - Drop the automatic configuration check (#1244, #1252)

--- a/Classes/Controller/UserWithoutAutologinController.php
+++ b/Classes/Controller/UserWithoutAutologinController.php
@@ -130,7 +130,7 @@ class UserWithoutAutologinController extends ActionController
     {
         $this->generateAndSetFullNameForUser($user);
         $this->credentialsGenerator->generateAndSetUsernameForUser($user);
-        $password = $this->credentialsGenerator->generateAndSetPasswordForUser($user);
+        $this->credentialsGenerator->generateAndSetPasswordForUser($user);
 
         $this->enrichWithPid($user);
         $this->enrichWithGroup($user, $userGroupUid);

--- a/Classes/Service/CredentialsGenerator.php
+++ b/Classes/Service/CredentialsGenerator.php
@@ -47,20 +47,17 @@ class CredentialsGenerator implements SingletonInterface
     }
 
     /**
-     * Generates a random long password, sets the password hash for the user, and returns the plain-text password
-     * (or `null` if the user already has a password).
+     * Generates a random long password and sets the password hash for the user.
      */
-    public function generateAndSetPasswordForUser(FrontendUser $user): ?string
+    public function generateAndSetPasswordForUser(FrontendUser $user): void
     {
         if ($user->getPassword() !== '') {
-            return null;
+            return;
         }
 
         $password = \bin2hex(\random_bytes(self::PASSWORD_LENGTH / 2));
         $passwordHash = $this->passwordHasher->getHashedPassword($password);
         $user->setPassword($passwordHash);
-
-        return $password;
     }
 
     private function generateAndSetUsernameFromEmail(FrontendUser $user): void

--- a/Tests/Functional/Service/CredentialsGeneratorTest.php
+++ b/Tests/Functional/Service/CredentialsGeneratorTest.php
@@ -139,29 +139,6 @@ final class CredentialsGeneratorTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function generateAndSetPasswordForUserWithExistingPasswordReturnsNull(): void
-    {
-        $user = new FrontendUser();
-        $existingPassword = 'gzuio134tfgzuiobft1234';
-        $user->setPassword($existingPassword);
-
-        $result = $this->subject->generateAndSetPasswordForUser($user);
-
-        self::assertNull($result);
-    }
-
-    #[Test]
-    public function generateAndSetPasswordForUserWithoutExistingPasswordReturnsTwelveCharacterPassword(): void
-    {
-        $user = new FrontendUser();
-
-        $result = $this->subject->generateAndSetPasswordForUser($user);
-
-        self::assertIsString($result);
-        self::assertMatchesRegularExpression('/^\\w{32}$/', $result);
-    }
-
-    #[Test]
     public function generateAndSetPasswordForUserWithoutExistingPasswordSetsPasswordHash(): void
     {
         $user = new FrontendUser();

--- a/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
+++ b/Tests/Unit/Controller/UserWithoutAutologinControllerTest.php
@@ -391,8 +391,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     #[Test]
     public function createActionWithUserReturnsHtmlResponse(): void
     {
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $result = $this->subject->createAction(new FrontendUser());
 
         self::assertInstanceOf(HtmlResponse::class, $result);
@@ -401,8 +399,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     #[Test]
     public function createActionWithoutUserReturnsHtmlResponse(): void
     {
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $result = $this->subject->createAction();
 
         self::assertInstanceOf(HtmlResponse::class, $result);
@@ -414,10 +410,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $systemFolderUid = 42;
         $this->subject->_set('settings', ['systemFolderForNewUsers' => (string)$systemFolderUid]);
         $user = new FrontendUser();
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -431,10 +423,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $group = new FrontendUserGroup();
         $this->subject->_set('settings', ['groupsForNewUsers' => (string)$groupUid]);
         $this->userGroupRepositoryMock->method('findByUid')->with($groupUid)->willReturn($group);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $user = new FrontendUser();
         $this->subject->createAction($user, $groupUid);
@@ -450,10 +438,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $groupUid2 = 5;
         $this->subject->_set('settings', ['groupsForNewUsers' => $groupUid1 . ',' . $groupUid2]);
         $this->userGroupRepositoryMock->method('findByUid')->with($groupUid1)->willReturn(null);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         /** @var ObjectStorage<FrontendUserGroup> $userGroupsFromRepository */
         $userGroupsFromRepository = new ObjectStorage();
         $userGroup2 = new FrontendUserGroup();
@@ -477,10 +461,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $groupUid1 = 4;
         $groupUid2 = 5;
         $this->subject->_set('settings', ['groupsForNewUsers' => $groupUid1 . ',' . $groupUid2]);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         /** @var ObjectStorage<FrontendUserGroup> $userGroupsFromRepository */
         $userGroupsFromRepository = new ObjectStorage();
         $userGroup1 = new FrontendUserGroup();
@@ -507,10 +487,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $groupUid1 = 4;
         $groupUid2 = 5;
         $this->subject->_set('settings', ['groupsForNewUsers' => $groupUid1 . ',' . $groupUid2]);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         /** @var ObjectStorage<FrontendUserGroup> $userGroupsFromRepository */
         $userGroupsFromRepository = new ObjectStorage();
         $userGroup1 = new FrontendUserGroup();
@@ -535,10 +511,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     public function createActionWithNullGroupUidAndNoConfiguredGroupsSetsNoGroups(): void
     {
         $this->subject->_set('settings', ['groupsForNewUsers' => '']);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $user = new FrontendUser();
         $this->subject->createAction($user, null);
@@ -553,10 +525,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $groupUid1 = 4;
         $groupUid2 = 5;
         $this->subject->_set('settings', ['groupsForNewUsers' => $groupUid1 . ',' . $groupUid2]);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         /** @var ObjectStorage<FrontendUserGroup> $userGroupsFromRepository */
         $userGroupsFromRepository = new ObjectStorage();
         $userGroup1 = new FrontendUserGroup();
@@ -583,10 +551,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $groupUid1 = 4;
         $groupUid2 = 5;
         $this->subject->_set('settings', ['groupsForNewUsers' => $groupUid1 . ',' . $groupUid2]);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         /** @var ObjectStorage<FrontendUserGroup> $userGroupsFromRepository */
         $userGroupsFromRepository = new ObjectStorage();
         $userGroup1 = new FrontendUserGroup();
@@ -612,10 +576,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $this->credentialsGeneratorMock->expects(self::once())->method('generateAndSetUsernameForUser')->with($user);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
     }
@@ -625,8 +585,9 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $this->credentialsGeneratorMock
-            ->expects(self::once())->method('generateAndSetPasswordForUser')
-            ->with($user)->willReturn('');
+            ->expects(self::once())
+            ->method('generateAndSetPasswordForUser')
+            ->with($user);
 
         $this->subject->createAction($user);
     }
@@ -635,8 +596,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     public function createActionSetsLastLoginToNow(): void
     {
         $user = new FrontendUser();
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $this->subject->createAction($user);
 
         $lastLoginDate = $user->getLastLogin();
@@ -649,8 +608,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $user->setTermsAcknowledged(false);
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $this->subject->createAction($user);
 
         self::assertNull($user->getTermsDateOfAcceptance());
@@ -661,8 +618,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $user->setTermsAcknowledged(true);
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $this->subject->createAction($user);
 
         $termsAcceptedDate = $user->getTermsDateOfAcceptance();
@@ -675,8 +630,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $user->setPrivacy(false);
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $this->subject->createAction($user);
 
         self::assertNull($user->getPrivacyDateOfAcceptance());
@@ -687,8 +640,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $user->setPrivacy(true);
-        $this->credentialsGeneratorMock->method('generateAndSetPasswordForUser')->willReturn('');
-
         $this->subject->createAction($user);
 
         $privacyAcceptedDate = $user->getPrivacyDateOfAcceptance();
@@ -704,10 +655,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user->setName($fullName);
         $user->setFirstName('Mini');
         $user->setLastName('Slowness');
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -721,10 +668,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user = new FrontendUser();
         $user->setName($fullName);
         $user->setFirstName('Mini');
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -738,10 +681,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user = new FrontendUser();
         $user->setName($fullName);
         $user->setLastName('Slowness');
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -756,10 +695,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user->setFirstName($firstName);
         $lastName = 'Slowness';
         $user->setLastName($lastName);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -773,10 +708,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user = new FrontendUser();
         $firstName = 'Mini';
         $user->setFirstName($firstName);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -789,10 +720,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $user = new FrontendUser();
         $lastName = 'Slowness';
         $user->setLastName($lastName);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -803,10 +730,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     public function createActionForUserWithNoNameAtAllKeepsEmptyFullyName(): void
     {
         $user = new FrontendUser();
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
 
@@ -818,10 +741,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $this->userRepositoryMock->expects(self::once())->method('add')->with($user);
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
     }
@@ -831,10 +750,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $user = new FrontendUser();
         $this->userRepositoryMock->expects(self::once())->method('persistAll');
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->subject->createAction($user);
     }
@@ -877,10 +792,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $this->postParameters['redirect_url'] = $redirectUrl;
 
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         $this->subject->expects(self::never())->method('redirectToUri');
 
         $this->subject->createAction(new FrontendUser());
@@ -892,10 +803,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $redirectUrl = self::SITE_URL;
         $this->postParameters['redirect_url'] = $redirectUrl;
 
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         $this->mockRedirectToUri($redirectUrl);
 
         $result = $this->subject->createAction(new FrontendUser());
@@ -907,10 +814,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
     {
         $this->postParameters['redirect_url'] = 'https://www.oliverklee.de/';
 
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
         $this->subject->expects(self::never())->method('redirectToUri');
 
         $this->subject->createAction(new FrontendUser());
@@ -932,11 +835,6 @@ final class UserWithoutAutologinControllerTest extends UnitTestCase
         $userUid = 42;
         $user = new FrontendUser();
         $user->_setProperty('uid', $userUid);
-
-        $this->credentialsGeneratorMock
-            ->method('generateAndSetPasswordForUser')
-            ->with(self::anything())
-            ->willReturn('');
 
         $this->userMock
             ->expects(self::once())


### PR DESCRIPTION
Fixes #1289